### PR TITLE
Refactor/config

### DIFF
--- a/docs/docs/api/configuration.md
+++ b/docs/docs/api/configuration.md
@@ -116,7 +116,7 @@ Supported syntax: `${VAR}`, `${VAR:-default}`, `${VAR-default}`, `${VAR:?err}`, 
 
 ### Retry Normalization
 
-`RunConfig.retry` is the canonical place for retry settings. Legacy top-level fields (`max_retries`, `retry_delay`, `jitter_factor`, `retry_exceptions`) are still accepted but are normalized into the nested `retry` block on load.
+`RunConfig.retry` is the canonical place for retry settings. Legacy top-level fields (`max_retries`, `retry_delay`, `jitter_factor`, `retry_exceptions`) are still accepted but are normalized into the nested `retry` block on load and now emit `DeprecationWarning` when set explicitly. Update configuration files to prefer the nested structure (e.g. `retry: {max_retries: 3, retry_delay: 2.0}`). Environment shims (`FP_MAX_RETRIES`, etc.) continue to work but likewise trigger deprecation notices.
 
 ### ProjectConfig
 **Module:** `flowerpower.cfg.ProjectConfig`

--- a/docs/docs/api/flowerpowerproject.md
+++ b/docs/docs/api/flowerpowerproject.md
@@ -37,6 +37,9 @@ run(self, name: str, run_config: RunConfig | None = None, inputs: dict | None = 
 
 Execute a pipeline synchronously and return its results.
 
+!!! warning "Legacy retry kwargs"
+    The standalone retry kwargs are retained for backwards compatibility and now emit `DeprecationWarning`. Prefer supplying retry settings via `run_config.retry` or the builder helpers.
+
 This is a convenience method that delegates to the pipeline manager. It provides the same functionality as `self.pipeline_manager.run()`.
 
 This method supports two primary ways of providing execution configuration:
@@ -60,10 +63,10 @@ When both `run_config` and individual parameters (`**kwargs`) are provided, the 
 | `adapter` | `dict[str, Any] \| None` | Custom adapter instance for pipeline Example: `{"ray_graph_adapter": RayGraphAdapter()}` | `None` |
 | `reload` | `bool` | Force reload of pipeline configuration. | `False` |
 | `log_level` | `str \| None` | Logging level for the execution. Valid values: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" | `None` |
-| `max_retries` | `int \| None` | Maximum number of retries for execution. | `None` |
-| `retry_delay` | `float \| None` | Delay between retries in seconds. | `None` |
-| `jitter_factor` | `float \| None` | Random jitter factor to add to retry delay | `None` |
-| `retry_exceptions` | `tuple \| list \| None` | Exceptions that trigger a retry. | `None` |
+| `max_retries` | `int \| None` | **Deprecated.** Legacy retry override; use `run_config.retry`. | `None` |
+| `retry_delay` | `float \| None` | **Deprecated.** Legacy retry override; use `run_config.retry`. | `None` |
+| `jitter_factor` | `float \| None` | **Deprecated.** Legacy retry override; use `run_config.retry`. | `None` |
+| `retry_exceptions` | `tuple \| list \| None` | **Deprecated.** Legacy retry override; use `run_config.retry`. | `None` |
 | `on_success` | `Callable \| tuple[Callable, tuple | None, dict | None] \| None` | Callback to run on successful pipeline execution. | `None` |
 | `on_failure` | `Callable \| tuple[Callable, tuple | None, dict | None] \| None` | Callback to run on pipeline execution failure. | `None` |
 
@@ -98,7 +101,8 @@ result = project.run(
 config = RunConfig(
     inputs={"data_date": "2025-01-01"},
     final_vars=["model", "metrics"],
-    log_level="DEBUG"
+    log_level="DEBUG",
+    retry={"max_retries": 2, "retry_delay": 1.0}
 )
 result = project.run("ml_pipeline", run_config=config)
 

--- a/docs/docs/api/pipelinemanager.md
+++ b/docs/docs/api/pipelinemanager.md
@@ -60,6 +60,9 @@ run(self, name: str, run_config: RunConfig | None = None, inputs: dict | None = 
 
 Execute a pipeline synchronously and return its results. Parameters related to retries (`max_retries`, `retry_delay`, `jitter_factor`, `retry_exceptions`) configure the internal retry mechanism.
 
+!!! warning "Legacy retry kwargs"
+    The standalone retry kwargs are retained for backwards compatibility and now emit `DeprecationWarning`. Prefer supplying retry settings via `run_config.retry` or the builder helpers.
+
 This method supports two primary ways of providing execution configuration:
 1. Using a `RunConfig` object (recommended): Provides a structured way to pass all execution parameters.
 2. Using individual parameters (`**kwargs`): Allows specifying parameters directly, which will override corresponding values in the `RunConfig` if both are provided.
@@ -81,10 +84,10 @@ When both `run_config` and individual parameters (`**kwargs`) are provided, the 
 | `adapter` | `dict[str, Any] \| None` | Custom adapter instance for pipeline Example: `{"ray_graph_adapter": RayGraphAdapter()}` | `None` |
 | `reload` | `bool` | Force reload of pipeline configuration. | `False` |
 | `log_level` | `str \| None` | Logging level for the execution. Valid values: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" | `None` |
-| `max_retries` | `int \| None` | Maximum number of retries for execution. | `None` |
-| `retry_delay` | `float \| None` | Delay between retries in seconds. | `None` |
-| `jitter_factor` | `float \| None` | Random jitter factor to add to retry delay | `None` |
-| `retry_exceptions` | `tuple \| list \| None` | Exceptions that trigger a retry. | `None` |
+| `max_retries` | `int \| None` | **Deprecated.** Legacy retry override; use `run_config.retry`. | `None` |
+| `retry_delay` | `float \| None` | **Deprecated.** Legacy retry override; use `run_config.retry`. | `None` |
+| `jitter_factor` | `float \| None` | **Deprecated.** Legacy retry override; use `run_config.retry`. | `None` |
+| `retry_exceptions` | `tuple \| list \| None` | **Deprecated.** Legacy retry override; use `run_config.retry`. | `None` |
 | `on_success` | `Callable \| tuple[Callable, tuple \| None, dict \| None] \| None` | Callback to run on successful pipeline execution. | `None` |
 | `on_failure` | `Callable \| tuple[Callable, tuple \| None, dict \| None] \| None` | Callback to run on pipeline execution failure. | `None` |
 

--- a/docs/docs/api/runconfig.md
+++ b/docs/docs/api/runconfig.md
@@ -16,6 +16,7 @@ __init__(
   cache: dict[str, Any] | bool | None = None,
   with_adapter: WithAdapterConfig | dict = WithAdapterConfig(),
   executor: ExecutorConfig | dict = ExecutorConfig(),
+  retry: RetryConfig | dict | None = None,
   log_level: str | None = "INFO",
   max_retries: int = 3,
   retry_delay: int | float = 1,
@@ -39,16 +40,17 @@ Initializes a `RunConfig` instance with execution parameters.
 | `config` | `dict[str, Any] \| None` | Configuration for Hamilton pipeline executor. Example: `{"model": "LogisticRegression"}` | `None` |
 | `cache` | `dict[str, Any] \| bool \| None` | Cache configuration for results or `False` to disable. | `False` |
 | `executor` | `ExecutorConfig \| dict` | Execution configuration; dict will be coerced to `ExecutorConfig`. | `ExecutorConfig()` |
+| `retry` | `RetryConfig \| dict \| None` | Canonical location for retry settings (max attempts, delay, jitter, exceptions). | `None` |
 | `with_adapter` | `WithAdapterConfig \| dict` | Adapter settings for pipeline execution; dict will be coerced to `WithAdapterConfig`. | `WithAdapterConfig()` |
 | `pipeline_adapter_cfg` | `dict \| PipelineAdapterConfig \| None` | Pipeline-specific adapter settings. Example: `{"tracker": {"project_id": "123", "tags": {"env": "prod"}}}` | `None` |
 | `project_adapter_cfg` | `dict \| ProjectAdapterConfig \| None` | Project-level adapter settings. Example: `{"opentelemetry": {"host": "http://localhost:4317"}}` | `None` |
 | `adapter` | `dict[str, Any] \| None` | Custom adapter instance for pipeline Example: `{"ray_graph_adapter": RayGraphAdapter()}` | `None` |
 | `reload` | `bool` | Force reload of pipeline configuration. | `False` |
 | `log_level` | `str \| None` | Logging level: "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL" | `"INFO"` |
-| `max_retries` | `int` | Maximum number of retries for execution. | `3` |
-| `retry_delay` | `int \| float` | Delay between retries in seconds. | `1` |
-| `jitter_factor` | `float \| None` | Random jitter factor to add to retry delay | `0.1` |
-| `retry_exceptions` | `list[str]` | Exception class names to trigger a retry (converted to classes). | `["Exception"]` |
+| `max_retries` | `int` | **Deprecated.** Legacy top-level value normalised into `retry`. | `3` |
+| `retry_delay` | `int \| float` | **Deprecated.** Legacy top-level value normalised into `retry`. | `1` |
+| `jitter_factor` | `float \| None` | **Deprecated.** Legacy top-level value normalised into `retry`. | `0.1` |
+| `retry_exceptions` | `list[str]` | **Deprecated.** Legacy top-level value normalised into `retry`. | `["Exception"]` |
 | `on_success` | `Callable \| tuple[Callable, tuple \| None, dict \| None] \| None` | Callback to run on successful pipeline execution. | `None` |
 | `on_failure` | `Callable \| tuple[Callable, tuple \| None, dict \| None] \| None` | Callback to run on pipeline execution failure. | `None` |
 
@@ -61,16 +63,18 @@ Initializes a `RunConfig` instance with execution parameters.
 | `config` | `dict[str, Any] \| None` | Configuration for Hamilton pipeline executor. |
 | `cache` | `dict[str, Any] \| None` | Cache configuration for results. |
 | `executor` | `ExecutorConfig` | Execution configuration. |
+| `executor_override_raw` | `Any \| None` | Raw executor override provided at runtime (string/dict/ExecutorConfig). |
 | `with_adapter` | `WithAdapterConfig` | Adapter settings for pipeline execution. |
+| `retry` | `RetryConfig` | Structured retry configuration used by the runner. |
 | `pipeline_adapter_cfg` | `dict \| PipelineAdapterConfig \| None` | Pipeline-specific adapter settings. |
 | `project_adapter_cfg` | `dict \| ProjectAdapterConfig \| None` | Project-level adapter settings. |
 | `adapter` | `dict[str, Any] \| None` | Custom adapter instance for pipeline. |
 | `reload` | `bool` | Force reload of pipeline configuration. |
 | `log_level` | `str \| None` | Logging level for the execution. |
-| `max_retries` | `int \| None` | Maximum number of retries for execution. |
-| `retry_delay` | `float \| None` | Delay between retries in seconds. |
-| `jitter_factor` | `float \| None` | Random jitter factor to add to retry delay. |
-| `retry_exceptions` | `tuple \| list \| None` | Exceptions that trigger a retry. |
+| `max_retries` | `int \| None` | **Deprecated.** Mirrors `retry.max_retries` for backwards compatibility. |
+| `retry_delay` | `float \| None` | **Deprecated.** Mirrors `retry.retry_delay`. |
+| `jitter_factor` | `float \| None` | **Deprecated.** Mirrors `retry.jitter_factor`. |
+| `retry_exceptions` | `tuple \| list \| None` | **Deprecated.** Mirrors `retry.retry_exceptions`. |
 | `on_success` | `Callable \| tuple[Callable, tuple \| None, dict \| None] \| None` | Callback to run on successful pipeline execution. |
 | `on_failure` | `Callable \| tuple[Callable, tuple \| None, dict \| None] \| None` | Callback to run on pipeline execution failure. |
 
@@ -601,3 +605,5 @@ manager = PipelineManager()
 # Run with different configurations
 training_result = manager.run("ml_pipeline", run_config=training_config)
 inference_result = manager.run("ml_pipeline", run_config=inference_config)
+!!! warning "Legacy retry fields"
+    The `max_retries`, `retry_delay`, `jitter_factor`, and `retry_exceptions` attributes are accepted for backwards compatibility but now trigger a `DeprecationWarning` when set explicitly. Prefer configuring retries via the nested `retry` block or the builder helpers.

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -39,9 +39,20 @@ The `FlowerPowerProject` class is the main entry point and public-facing API of 
 The `PipelineManager` is responsible for everything related to data pipelines:
 
 -   **Configuration:** It loads and manages pipeline definitions from YAML files.
--   **Execution:** It uses the Hamilton library to execute dataflows defined as a Directed Acyclic Graph (DAG) of Python functions.
+-   **Execution orchestration:** It coordinates with the new runtime stack (`PipelineRunner`, `ExecutionContextBuilder`, `RetryManager`) to execute Hamilton dataflows defined as a Directed Acyclic Graph (DAG) of Python functions.
 -   **Visualization:** It provides tools for visualizing pipeline graphs.
 -   **I/O:** It handles data loading and saving through an extensible system of I/O adapters.
+
+### Execution Runtime Stack
+
+To keep the `Pipeline` class lean and focused on configuration, the runtime responsibilities are delegated to specialised helpers:
+
+-   **`PipelineRunner`** – Owns the sync/async execution flow, applies `RunConfig` overrides, reloads modules when requested, and ensures logging/telemetry are initialised once per process.
+-   **`ExecutionContextBuilder`** – Resolves adapters and executors based on the merged configuration, including Ray shutdown hooks and custom adapters supplied at runtime.
+-   **`RetryManager`** – Implements retry/backoff logic, including jitter, callbacks, and parity between synchronous and asynchronous execution paths.
+-   **Telemetry & Logging helpers** – Consolidated utilities (`initialize_telemetry`, `ensure_logging_initialized`) eliminate import-time side effects and make log-level overrides predictable.
+
+This separation keeps responsibilities clear and makes it easier to extend or test the execution pipeline without touching configuration loading.
 
 #### Hamilton Integration
 

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -32,15 +32,15 @@ flowerpower pipeline run [OPTIONS] NAME
 - `--executor TEXT`: Executor to use for running the pipeline
 - `--base-dir TEXT`: Base directory for the pipeline
 - `--inputs TEXT`: Input parameters as JSON, dict string, or key=value pairs
-- `--final-vars TEXT`: Final variables as JSON or list
+- `--final-vars TEXT, --outputs TEXT, -o TEXT`: Final variables as JSON or list (alias: `--outputs`)
 - `--config TEXT`: Config for the hamilton pipeline executor
 - `--cache TEXT`: Cache configuration as JSON or dict string
 - `--storage-options TEXT`: Storage options as JSON, dict string, or key=value pairs
 - `--log-level TEXT`: Logging level (debug, info, warning, error, critical)
 - `--with-adapter TEXT`: Adapter configuration as JSON or dict string
-- `--max-retries INTEGER`: Maximum number of retry attempts on failure [default: 0]
-- `--retry-delay FLOAT`: Base delay between retries in seconds [default: 1.0]
-- `--jitter-factor FLOAT`: Random factor applied to delay for jitter (0-1) [default: 0.1]
+- `--max-retries INTEGER`: Maximum number of retry attempts on failure [default: 0] *(deprecated; prefer nested `retry` config)*
+- `--retry-delay FLOAT`: Base delay between retries in seconds [default: 1.0] *(deprecated; prefer nested `retry` config)*
+- `--jitter-factor FLOAT`: Random factor applied to delay for jitter (0-1) [default: 0.1] *(deprecated; prefer nested `retry` config)*
 
 **Examples:**
 ```bash
@@ -52,6 +52,9 @@ flowerpower pipeline run my_pipeline --inputs '{"data_date": "2025-04-28"}'
 
 # Specify final variables
 flowerpower pipeline run my_pipeline --final-vars '["result"]' --log-level DEBUG
+
+# Provide nested retry configuration via RunConfig
+flowerpower pipeline run my_pipeline --run-config '{"retry": {"max_retries": 3, "retry_delay": 2.0}}'
 ```
 
 #### pipeline new

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -201,7 +201,7 @@ config = (
     .with_inputs({"greeting_message": "Hello", "target_name": "World"})
     .with_final_vars(["full_greeting"])
     .with_log_level("DEBUG")
-    .with_retries(max_attempts=3, delay=1.0)
+    .with_retry_config(max_retries=3, retry_delay=1.0)
     .build()
 )
 

--- a/examples/hello-world/base/conf/pipelines/hello_world_parallel.yml
+++ b/examples/hello-world/base/conf/pipelines/hello_world_parallel.yml
@@ -25,17 +25,18 @@ run:
     type: threadpool
   final_vars: []
   inputs: {}
-  jitter_factor: 0.1
   log_level: INFO
-  max_retries: 3
   on_failure: null
   on_success: null
   pipeline_adapter_cfg: null
   project_adapter_cfg: null
   reload: false
-  retry_delay: 1
-  retry_exceptions:
-  - <class 'Exception'>
+  retry:
+    max_retries: 3
+    retry_delay: 1
+    jitter_factor: 0.1
+    retry_exceptions:
+      - Exception
   with_adapter:
     future: false
     hamilton_tracker: false

--- a/examples/hello-world/conf/pipelines/hello_world_parallel.yml
+++ b/examples/hello-world/conf/pipelines/hello_world_parallel.yml
@@ -25,17 +25,18 @@ run:
     type: threadpool
   final_vars: []
   inputs: {}
-  jitter_factor: 0.1
   log_level: INFO
-  max_retries: 3
   on_failure: null
   on_success: null
   pipeline_adapter_cfg: null
   project_adapter_cfg: null
   reload: false
-  retry_delay: 1
-  retry_exceptions:
-  - <class 'Exception'>
+  retry:
+    max_retries: 3
+    retry_delay: 1
+    jitter_factor: 0.1
+    retry_exceptions:
+      - Exception
   with_adapter:
     future: false
     hamilton_tracker: false

--- a/src/flowerpower/utils/env.py
+++ b/src/flowerpower/utils/env.py
@@ -15,6 +15,7 @@ import json
 import os
 import re
 from typing import Any, Mapping
+import warnings
 
 
 def _coerce_value(raw: str) -> Any:
@@ -151,12 +152,27 @@ def apply_global_shims(overrides: dict, project_overlay: dict, pipeline_overlay:
         tgt.setdefault("num_cpus", g["EXECUTOR_NUM_CPUS"])
 
     if "MAX_RETRIES" in g:
+        warnings.warn(
+            "Environment variable FP_MAX_RETRIES is deprecated; use FP_PIPELINE__RUN__RETRY__MAX_RETRIES instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         tgt = ensure_path(pipeline_overlay.setdefault("pipeline", {}), ["run", "retry"])
         tgt.setdefault("max_retries", g["MAX_RETRIES"])
     if "RETRY_DELAY" in g:
+        warnings.warn(
+            "Environment variable FP_RETRY_DELAY is deprecated; use FP_PIPELINE__RUN__RETRY__RETRY_DELAY instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         tgt = ensure_path(pipeline_overlay.setdefault("pipeline", {}), ["run", "retry"])
         tgt.setdefault("retry_delay", g["RETRY_DELAY"])
     if "JITTER_FACTOR" in g:
+        warnings.warn(
+            "Environment variable FP_JITTER_FACTOR is deprecated; use FP_PIPELINE__RUN__RETRY__JITTER_FACTOR instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         tgt = ensure_path(pipeline_overlay.setdefault("pipeline", {}), ["run", "retry"])
         tgt.setdefault("jitter_factor", g["JITTER_FACTOR"])
 
@@ -172,4 +188,3 @@ def merge_overlays_into_config(config_struct, project_overlay: dict, pipeline_ov
         cfg = getattr(config_struct, "pipeline")
         if hasattr(cfg, "update"):
             cfg.update(pipeline_overlay.get("pipeline", {}))
-

--- a/tests/cfg/test_run_config.py
+++ b/tests/cfg/test_run_config.py
@@ -159,7 +159,7 @@ class TestRunConfig:
     def test_run_config_from_dict_with_defaults(self):
         """Test RunConfig from_dict with minimal data."""
         data = {"inputs": {"x": 1}}
-        
+
         run_config = RunConfig.from_dict(data)
         
         assert run_config.inputs == {"x": 1}
@@ -170,6 +170,11 @@ class TestRunConfig:
         assert run_config.reload is False
         assert run_config.log_level == "INFO"  # Has default
         assert run_config.max_retries == 3  # Has default
+
+    def test_run_config_warns_on_legacy_retry_fields(self):
+        """Using deprecated top-level retry fields should emit a warning."""
+        with pytest.warns(DeprecationWarning):
+            RunConfig(max_retries=5)
 
 
 class TestRunConfigBuilder:

--- a/tests/pipeline/test_retry_manager.py
+++ b/tests/pipeline/test_retry_manager.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from flowerpower.pipeline.retry import RetryManager
+
+
+def test_retry_manager_calls_success_callback():
+    success_cb = MagicMock()
+    mgr = RetryManager(
+        max_retries=1,
+        retry_delay=0.1,
+        jitter_factor=0.0,
+        retry_exceptions=(Exception,),
+    )
+
+    result = mgr.execute(
+        operation=lambda: "ok",
+        on_success=success_cb,
+        on_failure=None,
+        context_name="test",
+    )
+
+    assert result == "ok"
+    success_cb.assert_called_once_with("ok", None)
+
+
+def test_retry_manager_calls_failure_callback():
+    failure_cb = MagicMock()
+    mgr = RetryManager(
+        max_retries=0,
+        retry_delay=0.1,
+        jitter_factor=0.0,
+        retry_exceptions=(ValueError,),
+    )
+
+    def boom():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        mgr.execute(
+            operation=boom,
+            on_success=None,
+            on_failure=failure_cb,
+            context_name="test",
+        )
+
+    failure_cb.assert_called_once()
+    args, kwargs = failure_cb.call_args
+    assert args[0] is None
+    assert isinstance(args[1], ValueError)

--- a/tests/pipeline/test_runner.py
+++ b/tests/pipeline/test_runner.py
@@ -104,3 +104,20 @@ def test_runner_async_path_parity(context_builder, pipeline_stub):
 
     assert result["remote"] is False
     assert FakeBuilder.last_instance.with_remote is False
+
+
+@patch("flowerpower.pipeline.runner.setup_logging")
+@patch("flowerpower.pipeline.runner.ExecutionContextBuilder")
+@patch("flowerpower.pipeline.runner.driver.Builder", FakeBuilder)
+def test_runner_applies_log_level(context_builder, mock_setup_logging, pipeline_stub):
+    runner = PipelineRunner(pipeline_stub)
+    context_builder.return_value.build.return_value = (
+        SimpleNamespace(),
+        None,
+        [],
+    )
+
+    run_config = RunConfig(executor=ExecutorConfig(type="synchronous"), log_level="DEBUG")
+    runner.run(run_config=run_config)
+
+    mock_setup_logging.assert_called_with(level="DEBUG")

--- a/uv.lock
+++ b/uv.lock
@@ -1245,7 +1245,7 @@ wheels = [
 
 [[package]]
 name = "flowerpower"
-version = "0.32.5"
+version = "0.32.6"
 source = { editable = "." }
 dependencies = [
     { name = "duration-parser" },


### PR DESCRIPTION
This pull request updates the documentation and configuration examples to standardize retry settings for pipeline execution, deprecating legacy top-level retry fields in favor of a structured nested `retry` block. It also clarifies the execution runtime stack and introduces new helpers for managing execution, retries, and logging. The changes promote consistency, improve maintainability, and guide users toward the new configuration style, while retaining backwards compatibility with deprecation warnings.

**Retry Configuration Modernization**

* The canonical place for retry settings is now the nested `retry` block within `RunConfig`. Legacy top-level retry fields (`max_retries`, `retry_delay`, `jitter_factor`, `retry_exceptions`) are still accepted but now emit `DeprecationWarning` and are marked as deprecated in documentation. Users are encouraged to update configuration files to use the nested structure. [[1]](diffhunk://#diff-49db61aaea2570101b0028ca190bc5eb210a0d4903692ee60952b26414533f85L119-R119) [[2]](diffhunk://#diff-7f34e1876b5da9ccfc6c4f3daec35120c2b02320e89b90bf999fbc87b46dc7d6R19) [[3]](diffhunk://#diff-7f34e1876b5da9ccfc6c4f3daec35120c2b02320e89b90bf999fbc87b46dc7d6R43-R53) [[4]](diffhunk://#diff-7f34e1876b5da9ccfc6c4f3daec35120c2b02320e89b90bf999fbc87b46dc7d6R66-R77) [[5]](diffhunk://#diff-7f34e1876b5da9ccfc6c4f3daec35120c2b02320e89b90bf999fbc87b46dc7d6R608-R609) [[6]](diffhunk://#diff-6d6c29e11efae8ae35646346b7a733f941cce58db6594c4a215337b729ea8f03L35-R43) [[7]](diffhunk://#diff-6d6c29e11efae8ae35646346b7a733f941cce58db6594c4a215337b729ea8f03R55-R57) [[8]](diffhunk://#diff-c09a64e496066d678f6cce498764957b0dffb3bb760414778816dcb960a1b50cL28-R39)
* Documentation for `PipelineManager`, `FlowerPowerProject`, and CLI usage now includes explicit warnings about deprecated retry kwargs and fields, and shows how to use the new nested `retry` configuration. [[1]](diffhunk://#diff-b2404d4e5a9529504a12e19fe154766867480581e891df9d91472b94aa2c6323R63-R65) [[2]](diffhunk://#diff-b2404d4e5a9529504a12e19fe154766867480581e891df9d91472b94aa2c6323L84-R90) [[3]](diffhunk://#diff-02e543595b406fa34a6fe9fe759d08faa1464b5da0a20be8c72df0e32f77254bR40-R42) [[4]](diffhunk://#diff-02e543595b406fa34a6fe9fe759d08faa1464b5da0a20be8c72df0e32f77254bL63-R69) [[5]](diffhunk://#diff-02e543595b406fa34a6fe9fe759d08faa1464b5da0a20be8c72df0e32f77254bL101-R105) [[6]](diffhunk://#diff-6d6c29e11efae8ae35646346b7a733f941cce58db6594c4a215337b729ea8f03L35-R43) [[7]](diffhunk://#diff-6d6c29e11efae8ae35646346b7a733f941cce58db6594c4a215337b729ea8f03R55-R57) [[8]](diffhunk://#diff-db23839e9fa71374d53983730e318028367dff34e8c817cd1e8acfec09624fe8L204-R204)

**Documentation and Example Updates**

* All relevant API docs and example YAML files have been updated to demonstrate usage of the nested `retry` block, and to mark legacy fields as deprecated. Example code and CLI usage now show how to provide retry settings using the new approach. [[1]](diffhunk://#diff-7f34e1876b5da9ccfc6c4f3daec35120c2b02320e89b90bf999fbc87b46dc7d6R43-R53) [[2]](diffhunk://#diff-7f34e1876b5da9ccfc6c4f3daec35120c2b02320e89b90bf999fbc87b46dc7d6R66-R77) [[3]](diffhunk://#diff-c09a64e496066d678f6cce498764957b0dffb3bb760414778816dcb960a1b50cL28-R39) [[4]](diffhunk://#diff-db23839e9fa71374d53983730e318028367dff34e8c817cd1e8acfec09624fe8L204-R204) [[5]](diffhunk://#diff-6d6c29e11efae8ae35646346b7a733f941cce58db6594c4a215337b729ea8f03R55-R57)

**Execution Runtime Clarification**

* The architecture documentation now describes the new execution runtime stack, introducing `PipelineRunner`, `ExecutionContextBuilder`, and `RetryManager` as specialized helpers for orchestrating execution, context resolution, and retries, clarifying the separation of configuration and runtime responsibilities.

**Improvements to API Reference and Examples**

* API documentation for `run` methods in `PipelineManager`, `FlowerPowerProject`, and executor modules has been clarified to reflect the new retry configuration mechanism, and to mark legacy retry-related kwargs as deprecated. [[1]](diffhunk://#diff-a48a8b37d31f5dd41b6a8ad1eb5ea1be6a2c013d03b89db7726bb610a338fab4L42-R47) [[2]](diffhunk://#diff-a48a8b37d31f5dd41b6a8ad1eb5ea1be6a2c013d03b89db7726bb610a338fab4L63-R64) [[3]](diffhunk://#diff-a48a8b37d31f5dd41b6a8ad1eb5ea1be6a2c013d03b89db7726bb610a338fab4L108-R90) [[4]](diffhunk://#diff-b2404d4e5a9529504a12e19fe154766867480581e891df9d91472b94aa2c6323R63-R65) [[5]](diffhunk://#diff-b2404d4e5a9529504a12e19fe154766867480581e891df9d91472b94aa2c6323L84-R90) [[6]](diffhunk://#diff-02e543595b406fa34a6fe9fe759d08faa1464b5da0a20be8c72df0e32f77254bR40-R42) [[7]](diffhunk://#diff-02e543595b406fa34a6fe9fe759d08faa1464b5da0a20be8c72df0e32f77254bL63-R69) [[8]](diffhunk://#diff-02e543595b406fa34a6fe9fe759d08faa1464b5da0a20be8c72df0e32f77254bL101-R105) [[9]](diffhunk://#diff-7f34e1876b5da9ccfc6c4f3daec35120c2b02320e89b90bf999fbc87b46dc7d6R19) [[10]](diffhunk://#diff-7f34e1876b5da9ccfc6c4f3daec35120c2b02320e89b90bf999fbc87b46dc7d6R43-R53) [[11]](diffhunk://#diff-7f34e1876b5da9ccfc6c4f3daec35120c2b02320e89b90bf999fbc87b46dc7d6R66-R77) [[12]](diffhunk://#diff-7f34e1876b5da9ccfc6c4f3daec35120c2b02320e89b90bf999fbc87b46dc7d6R608-R609)

**YAML Example Modernization**

* Example pipeline YAML files have been updated to use the nested `retry` structure, removing the legacy top-level retry fields and demonstrating the preferred configuration style.

These changes ensure a smoother migration path to the new configuration style while maintaining compatibility and providing clear guidance for users.This pull request updates the documentation and configuration for retry settings across the FlowerPower pipeline system. The main focus is to deprecate legacy top-level retry parameters in favor of a new, structured `retry` block within `RunConfig`. The changes clarify usage, update examples, and introduce deprecation warnings for old patterns, ensuring a smoother transition for users and more maintainable code.

**Retry Settings Modernization**

- Updated documentation throughout (`RunConfig`, `PipelineManager`, `FlowerPowerProject`, CLI, and API docs) to recommend using the nested `retry` block for all retry-related configuration, marking the legacy top-level fields (`max_retries`, `retry_delay`, `jitter_factor`, `retry_exceptions`) as deprecated and adding deprecation warnings when they're used. [[1]](diffhunk://#diff-7f34e1876b5da9ccfc6c4f3daec35120c2b02320e89b90bf999fbc87b46dc7d6R19) [[2]](diffhunk://#diff-7f34e1876b5da9ccfc6c4f3daec35120c2b02320e89b90bf999fbc87b46dc7d6R43-R53) [[3]](diffhunk://#diff-7f34e1876b5da9ccfc6c4f3daec35120c2b02320e89b90bf999fbc87b46dc7d6R66-R77) [[4]](diffhunk://#diff-49db61aaea2570101b0028ca190bc5eb210a0d4903692ee60952b26414533f85L119-R119) [[5]](diffhunk://#diff-7f34e1876b5da9ccfc6c4f3daec35120c2b02320e89b90bf999fbc87b46dc7d6R608-R609) [[6]](diffhunk://#diff-b2404d4e5a9529504a12e19fe154766867480581e891df9d91472b94aa2c6323R63-R65) [[7]](diffhunk://#diff-b2404d4e5a9529504a12e19fe154766867480581e891df9d91472b94aa2c6323L84-R90) [[8]](diffhunk://#diff-02e543595b406fa34a6fe9fe759d08faa1464b5da0a20be8c72df0e32f77254bR40-R42) [[9]](diffhunk://#diff-02e543595b406fa34a6fe9fe759d08faa1464b5da0a20be8c72df0e32f77254bL63-R69) [[10]](diffhunk://#diff-a48a8b37d31f5dd41b6a8ad1eb5ea1be6a2c013d03b89db7726bb610a338fab4L42-R47) [[11]](diffhunk://#diff-a48a8b37d31f5dd41b6a8ad1eb5ea1be6a2c013d03b89db7726bb610a338fab4L63-R64) [[12]](diffhunk://#diff-a48a8b37d31f5dd41b6a8ad1eb5ea1be6a2c013d03b89db7726bb610a338fab4L108-R90) [[13]](diffhunk://#diff-6d6c29e11efae8ae35646346b7a733f941cce58db6594c4a215337b729ea8f03L35-R43) [[14]](diffhunk://#diff-6d6c29e11efae8ae35646346b7a733f941cce58db6594c4a215337b729ea8f03R55-R57)

- Updated all relevant code examples and YAML pipeline configs to use the new `retry` structure, replacing legacy fields and demonstrating the recommended usage in both documentation and example files. [[1]](diffhunk://#diff-c09a64e496066d678f6cce498764957b0dffb3bb760414778816dcb960a1b50cL28-R39) [[2]](diffhunk://#diff-db23839e9fa71374d53983730e318028367dff34e8c817cd1e8acfec09624fe8L204-R204) [[3]](diffhunk://#diff-02e543595b406fa34a6fe9fe759d08faa1464b5da0a20be8c72df0e32f77254bL101-R105)

**Architecture and Execution Flow Documentation**

- Expanded architecture docs to describe the new runtime stack, including `PipelineRunner`, `ExecutionContextBuilder`, and `RetryManager`, clarifying the separation of configuration and execution responsibilities.

These changes improve clarity, future-proof retry configuration, and provide clear migration guidance for users.